### PR TITLE
Handle undelegated events

### DIFF
--- a/components/component.js
+++ b/components/component.js
@@ -96,9 +96,11 @@ export class Component extends HTMLElement {
   }
 
   undelegateEvents() {
-    for (const domEvent of this._domEvents) {
-      const els = [...this.querySelectorAll(domEvent.selector)];
-      this.unbindEvents(els, domEvent.eventName, this);
+    if (this._domEvents) {
+      for (const domEvent of this._domEvents) {
+        const els = [...this.querySelectorAll(domEvent.selector)];
+        this.unbindEvents(els, domEvent.eventName, this);
+      }
     }
 
     this._domEvents = [];

--- a/components/component.js
+++ b/components/component.js
@@ -18,7 +18,9 @@ export class Component extends HTMLElement {
   }
 
   disconnectedCallback() {
-    this.undelegateEvents();
+    if (typeof this.undelegateEvents === 'function') {
+      this.undelegateEvents();
+    }
   }
 
   get data() {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "orchestra-components",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "",
   "main": "index.js",
   "author": "Andrew Humphreys <ahumphreys87@googlemail.com>",
+  "contributors": "Liam Swinney <me@liamswinney.co.uk>",
   "license": "ISC",
   "dependencies": {
     "cherrytree": "^2.3.2",


### PR DESCRIPTION
```
Uncaught TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
    at HTMLElement.undelegateEvents (component.js:73)
    at HTMLElement.disconnectedCallback (component.js:14)
    at HTMLElement.render (component.js:82)
    at requestGames.gt.fetchGames.then.e (index.js:142)
```

```
Uncaught TypeError: this.undelegateEvents is not a function
    at HTMLElement.disconnectedCallback (component.js:14)
    at HTMLElement.render (component.js:82)
    at Gt.fetchGames.then.e (index.js:141)
```

handle when the func reference has been destroyed so errors when it's called
handle when undelegatedEvents is called but _domEvents has been removed 
