### PR TITLE
Add shadow dom to browsers that support it 

### DIFF
--- a/components/component.js
+++ b/components/component.js
@@ -119,18 +119,19 @@ export class Component extends HTMLElement {
 
   shouldComponentUpdate() {
     let isDirty = false;
+    const dataset = JSON.parse(JSON.stringify(this.dataset));
 
     if (this.currentData) {
-      for (const prop in this.data) {
-        if (Array.isArray(this.data[prop])) {
-          const isEqual = this.data[prop].every((element, index) => element === this.currentData[prop][index]);
+      for (const prop in dataset) {
+        if (Array.isArray(dataset[prop])) {
+          const isEqual = dataset[prop].every((element, index) => element === this.currentData[prop][index]);
 
           if (!isEqual) {
             isDirty = true;
             break;
           }
         } else {
-          if (this.data[prop] !== this.currentData[prop]) {
+          if (dataset[prop] !== this.currentData[prop]) {
             isDirty = true;
             break;
           }
@@ -140,7 +141,7 @@ export class Component extends HTMLElement {
       isDirty = true;
     }
 
-    this.currentData = this.data;
+    this.currentData = dataset;
 
     return isDirty;
   }

--- a/components/component.js
+++ b/components/component.js
@@ -10,6 +10,13 @@ const defaultMapDispatch = dispatch => ({ dispatch });
 export class Component extends HTMLElement {
   constructor() {
     super();
+
+    if (document.head.createShadowRoot || document.head.attachShadow) {
+        this.attachShadow({mode: 'open'});
+    } else {
+        this.shadowRoot = this;
+    }
+
     this.connectToStore();
   }
 
@@ -92,7 +99,7 @@ export class Component extends HTMLElement {
       const eventName = match[1];
       const selector = match[2];
       const method = this[this.events[event]];
-      const els = [...this.querySelectorAll(selector)];
+      const els = [...this.shadowRoot.querySelectorAll(selector)];
       this.bindEvents(els, eventName, method);
     }
   }
@@ -100,7 +107,7 @@ export class Component extends HTMLElement {
   undelegateEvents() {
     if (this._domEvents) {
       for (const domEvent of this._domEvents) {
-        const els = [...this.querySelectorAll(domEvent.selector)];
+        const els = [...this.shadowRoot.querySelectorAll(domEvent.selector)];
         this.unbindEvents(els, domEvent.eventName, this);
       }
     }
@@ -109,7 +116,7 @@ export class Component extends HTMLElement {
   }
 
   render() {
-    patch(this, this.template, this.data);
+    patch(this.shadowRoot, this.template, this.data);
 
     this.delegateEvents();
     this.onRender();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra-components",
-  "version": "0.8.1",
+  "version": "0.9.1",
   "description": "",
   "main": "index.js",
   "author": "Andrew Humphreys <ahumphreys87@googlemail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra-components",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "main": "index.js",
   "author": "Andrew Humphreys <ahumphreys87@googlemail.com>",


### PR DESCRIPTION
This is a breaking change as it'll require any dom interaction to use the shadowRoot  eg 'this.querySelector' updating to this.shadowRoot.querySelector'